### PR TITLE
refactor(shared): changing the profile preview layout

### DIFF
--- a/src/shared/ui/preview-profile/preview-profile.module.scss
+++ b/src/shared/ui/preview-profile/preview-profile.module.scss
@@ -1,5 +1,19 @@
 @import '@/shared/style/variables';
 
+%tag {
+	padding: 4px 12px;
+	color: $--Foreground-default;
+	display: inline-block;
+	border-radius: 20px;
+	white-space: nowrap;
+}
+%text {
+	margin: 0;
+	color: $--Foreground-default;
+	font-family: $--open-sans-font;
+	font-style: normal;
+}
+
 .previewWrapper {
 	display: flex;
 	flex-direction: column;
@@ -150,6 +164,25 @@
 	width: 24px;
 	height: 24px;
 }
+
+.tagsList {
+	margin: 0;
+	padding: 0;
+	list-style-type: none;
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+.tag {
+	@extend %text, %tag;
+	border: 1px solid $--border-default;
+	font-size: 14px;
+	font-weight: 400;
+	line-height: 19px;
+	letter-spacing: 0.25px;
+}
+
 
 @media screen and (max-width: 779px) {
 	.previewWrapper {

--- a/src/shared/ui/preview-profile/preview-profile.tsx
+++ b/src/shared/ui/preview-profile/preview-profile.tsx
@@ -23,6 +23,16 @@ export const PreviewProfile = () => {
 		setVisible(true);
 	};
 
+	const skills = [
+		{ id: 1, name: 'React' },
+		{ id: 2, name: 'Redux' },
+		{ id: 3, name: 'UI/UX Design' },
+		{ id: 4, name: 'React' },
+		{ id: 5, name: 'Redux' },
+		{ id: 6, name: 'UI/UX Design' },
+		{ id: 7, name: 'React' },
+	];
+
 	return (
 		<>
 			{!visible ? (
@@ -41,9 +51,6 @@ export const PreviewProfile = () => {
 								</div>
 
 								<div className={styles.previewFoto__infoActive}>
-									<p className={styles.previewFoto__infoRole}>
-										UX/UI designer / UX/UI дизайнер, Middle
-									</p>
 									<p className={styles.previewFoto__infoStatus}>
 										<ActiveIcon
 											className={styles.previewFoto__infoStatusActive}
@@ -53,14 +60,6 @@ export const PreviewProfile = () => {
 								</div>
 							</div>
 						</div>
-
-						<div className={styles.previewItem}>
-							<h2 className={styles.previewItem__title}>Навыки</h2>
-							<p className={styles.previewItem__subtitle}>
-								Python, JavaScript, C#, C++{' '}
-							</p>
-						</div>
-
 						<div className={styles.previewItem}>
 							<h2 className={styles.previewItem__title}>О себе</h2>
 							<p className={styles.previewItem__subtitle}>
@@ -73,6 +72,36 @@ export const PreviewProfile = () => {
 								Excepteur sint occaecat cupidatat non proident, sunt in culpa
 								qui officia deserunt mollit anim id est laborum, но приходится.
 							</p>
+						</div>
+
+						<div className={styles.previewItem}>
+							<h2 className={styles.previewItem__title}>
+								UX/UI designer / UX/UI дизайнер, Middle
+							</h2>
+							<ul className={styles.tagsList}>
+								{skills.map((item) => {
+									return (
+										<li key={item.id} className={styles.tag}>
+											{item.name}
+										</li>
+									);
+								})}
+							</ul>
+						</div>
+
+						<div className={styles.previewItem}>
+							<h2 className={styles.previewItem__title}>
+								UX/UI designer / UX/UI дизайнер, Middle
+							</h2>
+							<ul className={styles.tagsList}>
+								{skills.map((item) => {
+									return (
+										<li key={item.id} className={styles.tag}>
+											{item.name}
+										</li>
+									);
+								})}
+							</ul>
 						</div>
 
 						<div className={styles.previewItem}>


### PR DESCRIPTION
Небольшие изменения в макете превью профиля, поправила в верстке (Добавили 2 специальности с тегами-навыками, убрали специальность из шапки).
![2024-07-08_18-10-41](https://github.com/Pet-projects-CodePET/Frontend/assets/118973229/0a038001-8416-4a78-b6d7-64535cefa132)
